### PR TITLE
Bump Specmatic to 2.39.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-specmaticVersion=2.33.0
+specmaticVersion=2.39.2
 specmaticRedisVersion=0.9.5


### PR DESCRIPTION
## Summary
- bump Specmatic OSS version references to 2.39.2
- keep Specmatic Enterprise at 1.1.2

## Notes
- this PR updates dependency/version declarations only