### PR TITLE
refactor: add orchestrator workflow support

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,10 +1,22 @@
 name: Java CI with Gradle
 
+run-name: ${{ inputs.orchestrator_run_suffix && format('Java CI with Gradle - {0}', inputs.orchestrator_run_suffix) || github.workflow }}
+
 on:
   push:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
+    inputs:
+      enterprise_version:
+        description: Specmatic enterprise version under test
+        required: false
+        type: string
+      orchestrator_run_suffix:
+        description: Test orchestrator run suffix
+        required: false
+        type: string
   repository_dispatch:
     types: contracts changed
 jobs:
@@ -14,6 +26,8 @@ jobs:
         os: [ ubuntu-latest ]
         java: [17]
     runs-on: ${{ matrix.os }}
+    env:
+      ENTERPRISE_VERSION: ${{ inputs.enterprise_version }}
     steps:
     - uses: actions/checkout@v6
     - name: Set up JDK ${{ matrix.java }}
@@ -22,5 +36,14 @@ jobs:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}
 
+    # Internal setup required by Specmatic. Sample project users can ignore this block.
+    - if: ${{ inputs.orchestrator_run_suffix != '' }}
+      uses: specmatic/specmatic-github-workflows/action-orchestrator-setup@main
+      with:
+        orchestrator-run-suffix: ${{ inputs.orchestrator_run_suffix }}
+        docker-hub-username: ${{ vars.SPECMATIC_DOCKER_HUB_USERNAME }}
+        docker-hub-token: ${{ secrets.SPECMATIC_DOCKER_HUB_TOKEN }}
+    # End: internal setup required by Specmatic.
+
     - name: Build Redis sample project with Gradle
-      run: ./gradlew build
+      run: ./gradlew build ${ENTERPRISE_VERSION:+-PspecmaticEnterpriseVersion=${ENTERPRISE_VERSION}}


### PR DESCRIPTION
## Summary
- add workflow_dispatch inputs for orchestrator-triggered runs
- use the shared orchestrator setup action for snapshot runtime preparation
- pass the enterprise version through Gradle for orchestrator runs